### PR TITLE
Version bump for the latest packages and GHC 8.0 compilation

### DIFF
--- a/approximate.cabal
+++ b/approximate.cabal
@@ -1,6 +1,6 @@
 name:          approximate
 category:      Numeric
-version:       0.2.2.3
+version:       0.2.2.4
 license:       BSD3
 cabal-version: >= 1.8
 license-file:  LICENSE
@@ -43,17 +43,17 @@ flag herbie
 library
   build-depends:
     base                      >= 4.3      && < 5,
-    binary                    >= 0.5      && < 0.8,
+    binary                    >= 0.5      && < 0.9,
     bytes                     >= 0.7      && < 1,
     cereal                    >= 0.3.5    && < 0.6,
-    comonad                   >= 3        && < 5,
+    comonad                   >= 3        && < 6,
     deepseq                   >= 1.3      && < 1.5,
     ghc-prim,
     hashable                  >= 1.1.2.3  && < 1.3,
     hashable-extras           >= 0.1      && < 1,
     lens                      >= 3.9      && < 5,
     log-domain,
-    pointed                   >= 3        && < 5,
+    pointed                   >= 3        && < 6,
     semigroupoids             >= 3.0.2    && < 6,
     semigroups                >= 0.8.4    && < 1,
     safecopy                  >= 0.8.1    && < 0.10,


### PR DESCRIPTION
In a chase of SubHask and Herbie plugin to Stackage and GHC 8.0, the version bumps were made in this package to be compatible with the latest nightly Stackage.

Please review the changes and if they are ok, release the package to stackage.
