### PR TITLE
Add Hashable1 instances from hashable-1.2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,89 @@
-language: haskell
-before_install:
-  # Uncomment whenever hackage is down.
-  # - mkdir -p ~/.cabal && cp travis/config ~/.cabal/config && cabal update
-  - cabal update
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
 
-  # Try installing some of the build-deps with apt-get for speed.
-  - travis/cabal-apt-install $mode
-  - cabal install packdeps
-  - export PATH=~/.cabal/bin:$PATH
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+    # some doctests require type-level tricks, only in GHC >=7.8
+    - env: CABALVER=head GHCVER=7.4.2 TEST=--disable-tests
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-head,ghc-7.4.2], sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=7.6.3 TEST=--disable-tests
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-head,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-head,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-head,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=8.0.2
+      compiler: ": #GHC 8.0.2"
+      addons: {apt: {packages: [cabal-install-head,ghc-8.0.2], sources: [hvr-ghc]}}
+
+before_install:
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - TEST=${TEST---enable-tests}
 
 install:
-  - cabal configure -flib-Werror $mode
-  - cabal build
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cabal install --only-dependencies $TEST --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u $HOME/.cabsnap/installplan.txt installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies $TEST;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
 script:
-  - $script
-  - packdeps approximate.cabal
-  - hlint src --cpp-define HLINT
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure $TEST -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - if [ $TEST = "--enable-tests" ]; then cabal test; fi
+ - cabal sdist   # tests that a source-distribution can be generated
 
-notifications:
-  irc:
-    channels:
-      - "irc.freenode.org#haskell-lens"
-    skip_join: true
-    template:
-      - "\x0313approximate\x03/\x0306%{branch}\x03 \x0314%{commit}\x03 %{build_url} %{message}"
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
 
-env:
-  - mode="--enable-tests" script="cabal test --show-details=always"
+# EOF

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+0.2.3
+-----
+
+* Support `Hashable` from `hashable >= 1.2.5.0`
+
 0.2.2.3
 -------
 * Added support for `safecopy` 0.9 and `cereal` 0.5

--- a/Setup.lhs
+++ b/Setup.lhs
@@ -41,6 +41,10 @@ generateBuildModule verbosity pkg lbi = do
     withTestLBI pkg lbi $ \suite suitecfg -> do
       rewriteFile (dir </> "Build_" ++ testName suite ++ ".hs") $ unlines
         [ "module Build_" ++ testName suite ++ " where"
+        , ""
+        , "autogen_dir :: String"
+        , "autogen_dir = " ++ show dir
+        , ""
         , "deps :: [String]"
         , "deps = " ++ (show $ formatdeps (testDeps libcfg suitecfg))
         ]

--- a/approximate.cabal
+++ b/approximate.cabal
@@ -57,7 +57,7 @@ library
     semigroupoids             >= 3.0.2    && < 6,
     semigroups                >= 0.8.4    && < 1,
     safecopy                  >= 0.8.1    && < 0.10,
-    vector                    >= 0.9      && < 0.12
+    vector                    >= 0.9      && < 0.13
 
   if flag(herbie)
     build-depends: HerbiePlugin >= 0.1 && < 0.2

--- a/approximate.cabal
+++ b/approximate.cabal
@@ -1,6 +1,6 @@
 name:          approximate
 category:      Numeric
-version:       0.2.2.4
+version:       0.2.3
 license:       BSD3
 cabal-version: >= 1.8
 license-file:  LICENSE

--- a/approximate.cabal
+++ b/approximate.cabal
@@ -11,7 +11,7 @@ homepage:      http://github.com/analytics/approximate/
 bug-reports:   http://github.com/analytics/approximate/issues
 copyright:     Copyright (C) 2013 Edward A. Kmett
 build-type:    Custom
-tested-with:   GHC == 7.4.1, GHC == 7.6.1, GHC == 7.8.4, GHC == 7.10.1
+tested-with:   GHC == 7.4.1, GHC == 7.6.1, GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.2
 synopsis:      Approximate discrete values and numbers
 description:   This package provides approximate discrete values and numbers.
 

--- a/src/Data/Approximate/Mass.hs
+++ b/src/Data/Approximate/Mass.hs
@@ -32,8 +32,8 @@ import Data.Foldable
 #endif
 import Data.Functor.Bind
 import Data.Functor.Extend
-import Data.Hashable
-import Data.Hashable.Extras
+import Data.Hashable (Hashable(..))
+import qualified Data.Hashable.Extras as H.Extras
 import Data.Pointed
 import Data.SafeCopy
 import Data.Semigroup
@@ -46,6 +46,10 @@ import Data.Vector.Generic.Mutable as M
 import Data.Vector.Unboxed as U
 import GHC.Generics
 import Numeric.Log
+
+#if MIN_VERSION_hashable(1,2,5)
+import Data.Hashable.Lifted (Hashable1(..))
+#endif
 
 -- | A quantity with a lower-bound on its probability mass. This represents
 -- a 'probable value' as a 'Monad' that you can use to calculate progressively
@@ -77,7 +81,11 @@ instance Serialize a => Serialize (Mass a) where
 instance Serialize a => SafeCopy (Mass a)
 
 instance Hashable a => Hashable (Mass a)
-instance Hashable1 Mass
+instance H.Extras.Hashable1 Mass
+#if MIN_VERSION_hashable(1,2,5)
+instance Hashable1 Mass where
+    liftHashWithSalt h s (Mass m x) = hashWithSalt s m `h` x
+#endif
 
 instance Serial1 Mass where
   serializeWith f (Mass p a) = serialize p >> f a

--- a/src/Data/Approximate/Type.hs
+++ b/src/Data/Approximate/Type.hs
@@ -36,8 +36,8 @@ import Data.Data
 import Data.Foldable
 #endif
 import Data.Functor.Apply
-import Data.Hashable
-import Data.Hashable.Extras
+import Data.Hashable (Hashable(..))
+import qualified Data.Hashable.Extras as H.Extras
 import Data.Monoid
 import Data.Pointed
 import Data.SafeCopy
@@ -47,6 +47,10 @@ import Data.Vector.Generic.Mutable as M
 import Data.Vector.Unboxed as U
 import GHC.Generics
 import Numeric.Log
+
+#if MIN_VERSION_hashable(1,2,5)
+import Data.Hashable.Lifted (Hashable1(..))
+#endif
 
 -- | An approximate number, with a likely interval, an expected value and a lower bound on the @log@ of probability that the answer falls in the interval.
 --
@@ -69,7 +73,12 @@ instance Serialize a => Serialize (Approximate a) where
 instance Serialize a => SafeCopy (Approximate a)
 
 instance Hashable a => Hashable (Approximate a)
-instance Hashable1 Approximate
+instance H.Extras.Hashable1 Approximate
+#if MIN_VERSION_hashable(1,2,5)
+instance Hashable1 Approximate where
+    liftHashWithSalt h s (Approximate c low est high) =
+        hashWithSalt s c `h` low `h` est `h` high
+#endif
 
 instance Serial a => Serial (Approximate a)
 

--- a/tests/doctests.hsc
+++ b/tests/doctests.hsc
@@ -3,7 +3,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Main (doctests)
--- Copyright   :  (C) 2012-13 Edward Kmett
+-- Copyright   :  (C) 2012-14 Edward Kmett
 -- License     :  BSD-style (see the file LICENSE)
 -- Maintainer  :  Edward Kmett <ekmett@gmail.com>
 -- Stability   :  provisional
@@ -15,8 +15,10 @@
 -----------------------------------------------------------------------------
 module Main where
 
-import Build_doctests (deps)
+import Build_doctests (autogen_dir, deps)
+#if __GLASGOW_HASKELL__ < 710
 import Control.Applicative
+#endif
 import Control.Monad
 import Data.List
 import System.Directory
@@ -54,11 +56,13 @@ withUnicode m = m
 main :: IO ()
 main = withUnicode $ getSources >>= \sources -> doctest $
     "-isrc"
-  : "-idist/build/autogen"
+  : ("-i" ++ autogen_dir)
   : "-optP-include"
-  : "-optPdist/build/autogen/cabal_macros.h"
+  : ("-optP" ++ autogen_dir ++ "/cabal_macros.h")
   : "-hide-all-packages"
-  : "-Iincludes"
+#ifdef TRUSTWORTHY
+  : "-DTRUSTWORTHY=1"
+#endif
   : map ("-package="++) deps ++ sources
 
 getSources :: IO [FilePath]


### PR DESCRIPTION
tested locally against https://github.com/ekmett/hashable-extras/pull/5

Alternatively we can remove hashable-extras dependency completely, but that will require major bump. (as done in `log-domain`)

cc @RyanGlScott